### PR TITLE
Add screenshot directory configuration

### DIFF
--- a/roles/gnu_parallel/meta/main.yml
+++ b/roles/gnu_parallel/meta/main.yml
@@ -1,3 +1,4 @@
+# Ensure macports (which the role uses to install parallel) is installed.
 ---
 dependencies:
   - role: macports

--- a/roles/set_screenshot_location/defaults/main.yml
+++ b/roles/set_screenshot_location/defaults/main.yml
@@ -1,0 +1,4 @@
+# Default location for screenshots.
+---
+set_screenshots_location_folder: "{{ '~/Documents/Screenshots' | expanduser }}"
+

--- a/roles/set_screenshot_location/tasks/main.yml
+++ b/roles/set_screenshot_location/tasks/main.yml
@@ -1,0 +1,16 @@
+# Set the location for screen captures (images and videos).
+#
+# https://www.macrumors.com/how-to/change-screenshots-folder/
+---
+- name: Ensure screenshots folder exists
+  file:
+    path: "{{ set_screenshots_location_folder }}"
+    state: directory
+    mode: u=rwx
+
+- name: Set screenshots folder
+  osx_defaults:
+    domain: com.apple.screencapture
+    key: location
+    type: string
+    value: "{{ set_screenshots_location_folder }}"

--- a/setup-playbook.yml
+++ b/setup-playbook.yml
@@ -92,6 +92,14 @@
       tags:
         - customize
 
+    - import_role:
+        name: set_screenshot_location
+        apply:
+          tags:
+            - customize
+      tags:
+        - customize
+
     - import_tasks: tasks/ssh_setup.yml
       tags:
         - dotfiles


### PR DESCRIPTION
Add role to set the location where macOS saves screenshots, and add it to the setup playbook.