### PR TITLE
Add VLC role.

### DIFF
--- a/.idea/dictionaries/mike.xml
+++ b/.idea/dictionaries/mike.xml
@@ -19,6 +19,7 @@
       <w>nextstep</w>
       <w>noto</w>
       <w>passwordless</w>
+      <w>redownload</w>
       <w>skitch</w>
       <w>stix</w>
       <w>tempfile</w>

--- a/README.md
+++ b/README.md
@@ -74,3 +74,21 @@ python3 seems to be unable to verify ssl certificates without the full app).
 
 1. [JetBrains Mono](https://www.jetbrains.com/lp/mono/)
 1. [DejaVu](https://dejavu-fonts.github.io/)
+
+## Ansible footguns
+
+### Boolean extra vars
+
+Passing boolean values in `-e/--extra-vars`. If you pass `-e something=false` to ansible, `something` will have the 
+string value `"false"`. This string evaluates to `False` in most contexts when you type it in a playbook or in a vars
+file, but it does not do so as an extra var.  No, passing `-e something=False` doesn't work, either. `something` will
+have the string value `"False"`.
+
+Because many roles have boolean defaults that you may wish to override on the command line, this is a problem. There
+are several ways to deal with it:
+
+1. Use JSON. This syntax is cumbersome on the command line, but it works: `-e '{"something": false}'`. `False` also
+works here.
+2. Pass an empty value, which will evaluate to false in conditionals: `-e 'something='`.
+
+See [ansible 17193](https://github.com/ansible/ansible/issues/17193) and 

--- a/TODO.md
+++ b/TODO.md
@@ -8,13 +8,6 @@ In general, more app preferences...
 1. Install selected IDEs. The toolbox seems to be missing functionality to do this from the command line. Investigate
    AppleScript, Automator, etc.
 
-### VLC
-
-Automatically enable metadata retrieval, so I don't have to click on the popup, or even see the popup.
-
-See https://forum.videolan.org/viewtopic.php?t=126302 and
-https://community.jamf.com/t5/jamf-pro/suppressing-quot-enable-metadata-retrieval-quot-prompt-in-vlc/m-p/130327
-
 ### GPG tools
 
 GPG tools on requires some manual setup. Open Mail > Preferences > General, click on "Manage Plug-ins...",

--- a/roles/install_from_dmg/tasks/main.yml
+++ b/roles/install_from_dmg/tasks/main.yml
@@ -1,58 +1,54 @@
 ---
 - set_fact:
-    install_from_dmg_path_to_stat: "{{ app_destination }}/{{ app_name }}.app"
-  when: path_to_stat is not defined or path_to_stat == ''
-
-- set_fact:
-    install_from_dmg_path_to_stat: "{{ path_to_stat }}"
-  when: path_to_stat is defined and path_to_stat != ''
+    install_from_dmg_path_to_stat: "{{ app_destination }}/{{ install_from_dmg_app_name }}.app"
+  when: install_from_dmg_path_to_stat is not defined or install_from_dmg_path_to_stat == ''
 
 - name: Check for existing install
   stat:
     path: "{{ install_from_dmg_path_to_stat }}"
-  register: install_app_from_dmg_st
+  register: install_from_dmg_st
 
 - set_fact:
-    install_app_from_dmg_st: "{{ install_app_from_dmg_st.stat }}"
+    install_from_dmg_st: "{{ install_from_dmg_st.stat }}"
 
-- when: not (install_app_from_dmg_st.exists)
+- when: not (install_from_dmg_st.exists)
   block:
     - name: Download disk image
       get_url:
-        url: "{{ dmg_url }}"
-        dest: "{{ dmg_destination }}"
+        url: "{{ install_from_dmg_image_url }}"
+        dest: "{{ install_from_dmg_image_destination }}"
         mode: u=rw
-      when: not dmg_checksum
+      when: install_from_dmg_image_checksum is not defined
 
     - name: Download disk image and verify checksum
       get_url:
-        url: "{{ dmg_url }}"
-        dest: "{{ dmg_destination }}"
-        checksum: "{{ dmg_checksum }}"
+        url: "{{ install_from_dmg_image_url }}"
+        dest: "{{ install_from_dmg_image_destination }}"
+        checksum: "{{ install_from_dmg_image_checksum }}"
         mode: u=rw
-      when: dmg_checksum
+      when: install_from_dmg_image_checksum is defined
 
     - include_role:
         name: mount_dmg
       vars:
-        path: "{{ dmg_destination }}"
-        mountpoint: "{{ app_name }}"
+        path: "{{ install_from_dmg_image_destination }}"
+        mountpoint: "{{ install_from_dmg_app_name }}"
 
     - name: Copy app to destination
-      command: "cp -a '/Volumes/{{ app_name }}/{{ app_name }}.app' '{{ app_destination }}'"
+      command: "cp -a '/Volumes/{{ install_from_dmg_app_name }}/{{ install_from_dmg_app_name }}.app' /Applications"
       when: install_method == 'cp'
 
     - name: Install package
-      command: "installer -pkg '/Volumes/{{ app_name }}/{{ install_method }}' -target /"
+      command: "installer -pkg '/Volumes/{{ install_from_dmg_app_name }}/{{ install_from_dmg_install_method }}' -target /"
       when: install_method is regex('^.*\.pkg$')
       become: true
 
     - name: Run installer app
-      command: "open -a '/Volumes/{{ app_name }}/{{ install_method }}'"
+      command: "open -a '/Volumes/{{ install_from_dmg_app_name }}/{{ install_from_dmg_install_method }}'"
       when: install_method is regex('^.*\.app$')
 
   always:
     - include_role:
         name: unmount_dmg
       vars:
-        mountpoint: "{{ app_name }}"
+        mountpoint: "{{ install_from_dmg_app_name }}"

--- a/roles/vlc/defaults/main.yml
+++ b/roles/vlc/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# true forces redownload, even if dmg is already present.
+vlc_force_download: false
+# true forces reinstall, even if app is present.
+vlc_force_install: false
+
+# Destination for the disk image file in the download directory.
+vlc_dmg_name: VLC.dmg
+# Name of the pkg within the mounted disk image.
+vlc_package_name: VLC.pkg

--- a/roles/vlc/defaults/main.yml
+++ b/roles/vlc/defaults/main.yml
@@ -8,3 +8,8 @@ vlc_force_install: false
 vlc_dmg_name: VLC.dmg
 # Name of the pkg within the mounted disk image.
 vlc_package_name: VLC.pkg
+
+# false to disable metadata retrieval.
+vlc_enable_metadata_retrieval: true
+# false to disable update checking
+vlc_enable_automatic_updates: true

--- a/roles/vlc/tasks/main.yml
+++ b/roles/vlc/tasks/main.yml
@@ -1,0 +1,16 @@
+# Install VLC version `vlc_version`.
+---
+- set_fact:
+    vlc_dmg_suffix: "{{ 'intel64' if (ansible_machine == 'x86_64') else ansible_machine }}"
+- set_fact:
+    vlc_dmg_url: "https://get.videolan.org/vlc/{{ vlc_version }}/macosx/vlc-{{ vlc_version }}-{{ vlc_dmg_suffix }}.dmg"
+
+- name: Download and install VLC
+  include_role:
+    name: install_from_dmg
+  vars:
+    install_from_dmg_app_name: "VLC"
+    install_from_dmg_image_url: "{{ vlc_dmg_url }}"
+    install_from_dmg_image_destination: "{{ downloads }}/VLC.dmg"
+    install_from_dmg_force_download: "{{ vlc_force_download }}"
+    install_from_dmg_install: "{{ vlc_force_install }}"

--- a/roles/vlc/tasks/main.yml
+++ b/roles/vlc/tasks/main.yml
@@ -4,6 +4,8 @@
     vlc_dmg_suffix: "{{ 'intel64' if (ansible_machine == 'x86_64') else ansible_machine }}"
 - set_fact:
     vlc_dmg_url: "https://get.videolan.org/vlc/{{ vlc_version }}/macosx/vlc-{{ vlc_version }}-{{ vlc_dmg_suffix }}.dmg"
+- set_fact:
+    vlc_config_file: "{{ '~/Library/Preferences/org.videolan.vlc/vlcrc' | expanduser }}"
 
 - name: Download and install VLC
   include_role:
@@ -14,3 +16,63 @@
     install_from_dmg_image_destination: "{{ downloads }}/VLC.dmg"
     install_from_dmg_force_download: "{{ vlc_force_download }}"
     install_from_dmg_install: "{{ vlc_force_install }}"
+
+# See https://community.jamf.com/t5/jamf-pro/suppressing-quot-enable-metadata-retrieval-quot-prompt-in-vlc/m-p/130327
+# and https://forum.videolan.org/viewtopic.php?t=126302 (linked from above).
+- name: Disable the metadata retrieval popup
+  osx_defaults:
+    domain: org.videolan.vlc
+    key: VLCFirstRun
+    type: date
+    value: "2021-11-29 23:43:21 +0000"  # any valid date will do, apparently.
+
+- name: Ensure configuration directory exists
+  file:
+    path: "{{ vlc_config_file | dirname }}"
+    state: directory
+    mode: u=rwx
+
+- name: Ensure configuration file exists
+  file:
+    path: "{{ vlc_config_file }}"
+    state: touch
+    mode: u=rw
+
+# First remove the existing setting (which will not be present if the file is newly-created), then add the new setting.
+# lineinfile can't add a line to an empty file if we also want a replacement regex, so each toggle has to be done in
+# two steps.
+
+- when: vlc_enable_metadata_retrieval | bool
+  name: Enable metadata retrieval
+  block:
+    - name: Remove metadata retrieval disabled setting
+      lineinfile:
+        path: "{{ vlc_config_file }}"
+        regexp: "#?metadata-network-access=0"
+        state: absent
+    - name: Add metadata retrieval enabled setting
+      lineinfile:
+        path: "{{ vlc_config_file }}"
+        line: "metadata-network-access=1"
+        state: present
+
+- when: not(vlc_enable_metadata_retrieval | bool)
+  name: Disable metadata retrieval
+  block:
+    - name: Remove metadata retrieval enabled setting
+      lineinfile:
+        path: "{{ vlc_config_file }}"
+        regexp: "#?metadata-network-access=1"
+        state: absent
+    - name: Add metadata retrieval disabled setting
+      lineinfile:
+        path: "{{ vlc_config_file }}"
+        line: "#metadata-network-access=0"
+        state: present
+
+- name: Set automatic update preference
+  osx_defaults:
+    domain: org.videolan.vlc
+    key: SUEnableAutomaticChecks
+    type: bool
+    value: "{{ true if vlc_enable_automatic_updates else false }}"

--- a/tasks/install_apps.yml
+++ b/tasks/install_apps.yml
@@ -34,17 +34,21 @@
   include_role:
     name: aws_cli
 
+- name: Install VLC
+  include_role:
+    name: vlc
+
 - name: Download and install app from disk images
   include_role:
     name: install_from_dmg
   vars:
-    dmg_url: "{{ item.dmg_url }}"
-    dmg_destination: "{{ downloads }}/{{ item.app_name }}.dmg"
-    dmg_checksum: "{{ item.checksum | default(None) }}"
-    app_name: "{{ item.app_name }}"
+    install_from_dmg_image_url: "{{ item.dmg_url }}"
+    install_from_dmg_image_destination: "{{ downloads }}/{{ item.app_name }}.dmg"
+    install_from_dmg_image_checksum: "{{ item.checksum | default(None) }}"
+    install_from_dmg_app_name: "{{ item.app_name }}"
     # default(omit) doesn't work here, annoyingly
-    path_to_stat: "{{ item.path_to_stat | default(None) }}"
-    install_method: "{{ item.install_method | default('cp') }}"
+    install_from_dmg_path_to_stat: "{{ item.path_to_stat | default(None) }}"
+    install_from_dmg_install_method: "{{ item.install_method | default('cp') }}"
   loop: "{{ dmgs_to_download_and_install }}"
 
 - name: List installed apps

--- a/vars/dmgs.yml
+++ b/vars/dmgs.yml
@@ -43,10 +43,6 @@ dmgs_to_download_and_install:
     install_method: XQuartz.pkg
     path_to_stat: /usr/X11/bin/Xquartz
 
-  # arch
-  - app_name: VLC
-    dmg_url: "https://get.videolan.org/vlc/{{ vlc_version }}/macosx/vlc-{{ vlc_version }}-intel64.dmg"
-
   - app_name: VisualVM
     dmg_url: "https://github.com/visualvm/visualvm.src/releases/download/{{ visualvm_version }}/VisualVM_{{ visualvm_version | replace('.', '') }}.dmg"
 


### PR DESCRIPTION
VLC has separate images for Intel and Apple silicon, plus I want to be able to configure some settings.

1. Clean up the `install_from_dmg` role (role variables should be properly prefixed).
2. Add a new `vlc` role specifically to install VLC. It uses `install_from_dmg` under the hood.