### PR TITLE
Move versions to the role defaults.

### DIFF
--- a/roles/iterm2/defaults/main.yml
+++ b/roles/iterm2/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+iterm2_version: "3.5.11"
 iterm2_app_path: /Applications
 iterm2_app_name: iTerm
 iterm2_force_download: false

--- a/roles/macports/defaults/main.yml
+++ b/roles/macports/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+macports_version: "2.10.5"
 macports_force_download: false
 macports_force_install: false

--- a/roles/macports/tasks/main.yml
+++ b/roles/macports/tasks/main.yml
@@ -1,4 +1,5 @@
 # Download and install MacPorts
+#  https://www.macports.org/
 ---
 - stat:
     path: /opt/local/bin/port

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Version of node to install.
+node_version: "22.12.0"
+
 # Version of node to install. None => use the default that came with node. 'latest' => install latest version.
 node_npm_version:
 # Version of yarn to install. None => don't install any. 'latest' => install latest version.

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -1,4 +1,7 @@
 # Install node via nvm.
+#  https://github.com/nvm-sh/nvm
+#
+# This installs nvm by cloning its GitHub repository. It then uses nvm to install the requested node version.
 ---
 - set_fact:
     node_nvm_home: "{{ '~/.nvm' | expanduser }}"

--- a/roles/r_app/defaults/main.yml
+++ b/roles/r_app/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+r_app_version: "4.4.3"
 r_app_force_download: false
 r_app_force_install: false

--- a/roles/r_app/tasks/main.yml
+++ b/roles/r_app/tasks/main.yml
@@ -1,4 +1,5 @@
 # Install the R app.
+#  https://www.r-project.org/
 ---
 - stat:
     path: /Applications/R.app

--- a/roles/terraform/defaults/main.yml
+++ b/roles/terraform/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+terraform_version: "1.11.2"
 terraform_force_download: false
 terraform_force_install: false

--- a/roles/terraform/tasks/main.yml
+++ b/roles/terraform/tasks/main.yml
@@ -1,6 +1,5 @@
 # Install terraform
-#
-# Set terraform_force_install to true to reinstall.
+#  https://www.terraform.io/
 ---
 - stat:
     path: "/usr/local/bin/terraform"

--- a/roles/vlc/defaults/main.yml
+++ b/roles/vlc/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+vlc_version: "3.0.21"
+
 # true forces redownload, even if dmg is already present.
 vlc_force_download: false
 # true forces reinstall, even if app is present.

--- a/roles/vlc/tasks/main.yml
+++ b/roles/vlc/tasks/main.yml
@@ -1,4 +1,5 @@
 # Install VLC version `vlc_version`.
+#  https://www.videolan.org/
 ---
 - set_fact:
     vlc_dmg_suffix: "{{ 'intel64' if (ansible_machine == 'x86_64') else ansible_machine }}"

--- a/roles/xact/defaults/main.yml
+++ b/roles/xact/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+xact_version: "2.57"
+
 xact_app_path: /Applications
 xact_app_name: xACT
 xact_force_download: false

--- a/roles/xact/tasks/main.yml
+++ b/roles/xact/tasks/main.yml
@@ -1,4 +1,5 @@
 # Install xACT
+#  https://xact.scottcbrown.org/
 ---
 - stat:
     path: "{{ xact_app_path }}/{{ xact_app_name }}.app"

--- a/vars/versions.yml
+++ b/vars/versions.yml
@@ -2,13 +2,6 @@
 # Remember to enclose versions ending in .0 in quotes. Probably best to just quote them all, really.
 ---
 gpgtools_version: "2023.3"
-iterm2_version: "3.5.10"
-macports_version: "2.10.5"
-node_version: "22.12.0"
 picard_version: "2.12.3"
-r_app_version: "4.4.2"
 skim_version: "1.7.6"
-terraform_version: "1.10.0"
 visualvm_version: "2.1.10"
-vlc_version: "3.0.21"
-xact_version: "2.55"


### PR DESCRIPTION
Updated relevant versions as well.

Affects iterm2, macports, node, R, terraform, vlc, xact.

I think it makes way more sense to keep role variables with the roles, and to move more of this stuff to specific roles over time.

It's still possible to override the default using a variable (here, command line, whatever). But the role should work out of the box.