### PR TITLE
Add argument specs to most roles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ANSIBLE_HOME, if it's set here.
+.ansible/

--- a/.idea/dictionaries/mike.xml
+++ b/.idea/dictionaries/mike.xml
@@ -22,6 +22,7 @@
       <w>passwordless</w>
       <w>redownload</w>
       <w>skitch</w>
+      <w>steamcmd</w>
       <w>stix</w>
       <w>tempfile</w>
       <w>unarchive</w>

--- a/.idea/mac-setup.iml
+++ b/.idea/mac-setup.iml
@@ -2,7 +2,9 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.ansible" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/roles/aws_cli/defaults/main.yml
+++ b/roles/aws_cli/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 aws_cli_force_download: false
 aws_cli_force_install: false
-aws_cli_package_name: AWSCLIV2.pkg

--- a/roles/aws_cli/meta/argument_specs.yml
+++ b/roles/aws_cli/meta/argument_specs.yml
@@ -1,0 +1,16 @@
+---
+argument_specs:
+  main:
+    short_description: Install the aws cli.
+    description: >-
+      Downloads and installs the aws cli.
+    options:
+      aws_cli_force_download:
+        description: >-
+          If True, download the aws cli, even if it's already been downloaded.
+        type: bool
+        default: false
+      aws_cli_force_install:
+        description: >-
+          If True, install the aws cli, even if it's already installed.
+        default: false

--- a/roles/aws_cli/tasks/main.yml
+++ b/roles/aws_cli/tasks/main.yml
@@ -3,6 +3,9 @@
     path: /usr/local/bin/aws
   register: throwaway
 
+- set_fact:
+    aws_cli_package_name: AWSCLIV2.pkg
+
 - name: Download AWS CLI installer
   get_url:
     url: "https://awscli.amazonaws.com/{{ aws_cli_package_name }}"

--- a/roles/aws_sam_cli/meta/argument_specs.yml
+++ b/roles/aws_sam_cli/meta/argument_specs.yml
@@ -1,0 +1,16 @@
+---
+argument_specs:
+  main:
+    short_description: Install the aws sam cli.
+    description: >-
+      Downloads and installs the aws sam cli.
+    options:
+      aws_sam_cli_force_download:
+        description: >-
+          If True, download the aws sam cli, even if it's already been downloaded.
+        type: bool
+        default: false
+      aws_sam_cli_force_install:
+        description: >-
+          If True, install the aws sam cli, even if it's already installed.
+        default: false

--- a/roles/docker/meta/argument_specs.yml
+++ b/roles/docker/meta/argument_specs.yml
@@ -1,0 +1,17 @@
+---
+argument_specs:
+  main:
+    short_description: Install Docker.
+    description: >-
+      Installs the Docker Desktop app.
+    options:
+      docker_force_download:
+        description: >-
+          If True, download Docker, even if it's already been downloaded.
+        type: bool
+        default: false
+      docker_force_install:
+        description: >-
+          If True, install Docker, even if it's already been installed.
+        type: bool
+        default: false

--- a/roles/doppler/meta/argument_specs.yml
+++ b/roles/doppler/meta/argument_specs.yml
@@ -1,0 +1,21 @@
+---
+argument_specs:
+  main:
+    short_description: Install doppler.
+    description: >-
+      Downloads and installs doppler.
+    options:
+      doppler_binary_directory:
+        description: >-
+          Directory to which the doppler binary will be installed.
+        type: path
+        default: ~/bin
+      doppler_force_download:
+        description: >-
+          If True, download doppler, even if it's already been downloaded.
+        type: bool
+        default: false
+      doppler_force_install:
+        description: >-
+          If True, install doppler, even if it's already installed.
+        default: false

--- a/roles/emacs/defaults/main.yml
+++ b/roles/emacs/defaults/main.yml
@@ -2,5 +2,4 @@
 emacs_bootstrap: false
 emacs_distclean: false
 emacs_extraclean: true
-# Directory where emacs source lives.
 emacs_src_dir: "{{ '~/src/emacs' | expanduser }}"

--- a/roles/emacs/defaults/main.yml
+++ b/roles/emacs/defaults/main.yml
@@ -1,9 +1,6 @@
 ---
-# Whether to run the (fairly slow and expensive) bootstrap build step.
 emacs_bootstrap: false
-# Whether to run make distclean before configuring emacs. Mutually exclusive with extraclean.
 emacs_distclean: false
-# Whether to run make extraclean before configuring emacs. Mutually exclusive with distclean.
 emacs_extraclean: true
 # Directory where emacs source lives.
 emacs_src_dir: "{{ '~/src/emacs' | expanduser }}"

--- a/roles/emacs/meta/argument_specs.yml
+++ b/roles/emacs/meta/argument_specs.yml
@@ -1,0 +1,30 @@
+---
+argument_specs:
+  main:
+    short_description: Install emacs from source.
+    description: >-
+      Clones the emacs repo (github), then builds and installs the application.
+    options:
+      emacs_bootstrap:
+        description: >-
+          Whether to run the (fairly slow and expensive) bootstrap build step.
+        type: bool
+        default: false
+      emacs_distclean:
+        description: >-
+          Whether to run make distclean before configuring emacs. 
+          
+          Mutually exclusive with emacs_extraclean.
+        type: bool
+        default: false
+      emacs_extraclean:
+        description: >-
+          Whether to run make extraclean before configuring emacs.
+          
+          Mutually exclusive with emacs_distclean.
+        default: true
+      emacs_src_dir:
+        description: >-
+          Destination for the cloned emacs repository.
+        type: path
+        default: ~/src/emacs

--- a/roles/gnu_parallel/meta/argument_specs.yml
+++ b/roles/gnu_parallel/meta/argument_specs.yml
@@ -1,0 +1,8 @@
+---
+argument_specs:
+  main:
+    short_description: Install GNU parallel using MacPorts.
+    description: >-
+      Installs GNU parallel using MacPorts, and silences the citation warning.
+    options:
+

--- a/roles/iterm2/meta/argument_specs.yml
+++ b/roles/iterm2/meta/argument_specs.yml
@@ -12,8 +12,9 @@ argument_specs:
         default: iTerm2
       iterm2_app_path:
         description: >-
-          Directory where the iTerm2 application should be installed. For example, `/Applications` or 
-          `{{ '~/Applications' | expanduser }}` would be reasonable choices.
+          Directory where the iTerm2 application should be installed.
+          
+          For example, `/Applications` or `{{ '~/Applications' | expanduser }}` would be reasonable choices.
         type: path
         default: /Applications
       iterm2_force_download:

--- a/roles/iterm2/meta/argument_specs.yml
+++ b/roles/iterm2/meta/argument_specs.yml
@@ -1,0 +1,32 @@
+---
+argument_specs:
+  main:
+    short_description: Install iTerm2.
+    description: >-
+      Downloads and installs iTerm2.
+    options:
+      iterm2_app_name:
+        description: >-
+          Name of the iTerm2 application
+        type: str
+        default: iTerm2
+      iterm2_app_path:
+        description: >-
+          Directory where the iTerm2 application should be installed. For example, `/Applications` or 
+          `{{ '~/Applications' | expanduser }}` would be reasonable choices.
+        type: path
+        default: /Applications
+      iterm2_force_download:
+        description: >-
+          If True, download iTerm2, even if it's already been downloaded.
+        type: bool
+        default: false
+      iterm2_force_install:
+        description: >-
+          If True, install iTerm2, even if it's already installed.
+        default: false
+      iterm2_version:
+        description: >-
+          The version of iTerm2 to install.
+        type: str
+        # Default changes often. See defaults.

--- a/roles/macports/meta/argument_specs.yml
+++ b/roles/macports/meta/argument_specs.yml
@@ -1,0 +1,21 @@
+---
+argument_specs:
+  main:
+    short_description: Install MacPorts.
+    description: >-
+      Downloads and installs MacPorts.
+    options:
+      macports_force_download:
+        description: >-
+          If True, download MacPorts, even if it's already been downloaded.
+        type: bool
+        default: false
+      macports_force_install:
+        description: >-
+          If True, install MacPorts, even if it's already installed.
+        default: false
+      macports_version:
+        description: >-
+          The version of MacPorts to install
+        required: false
+        # See defaults for default version.

--- a/roles/mactex/meta/argument_specs.yml
+++ b/roles/mactex/meta/argument_specs.yml
@@ -1,0 +1,16 @@
+---
+argument_specs:
+  main:
+    short_description: Install MacTeX.
+    description: >-
+      Downloads and installs MacTeX.
+    options:
+      mactex_force_download:
+        description: >-
+          If True, download MacTeX, even if it's already been downloaded.
+        type: bool
+        default: false
+      mactex_force_install:
+        description: >-
+          If True, install MacTeX, even if it's already installed.
+        default: false

--- a/roles/ngrok/defaults/main.yml
+++ b/roles/ngrok/defaults/main.yml
@@ -1,5 +1,3 @@
 ---
 ngrok_force_download: false
 ngrok_force_install: false
-# This is a component of the download URL. It used to change frequently. These days, not so much.
-ngrok_hash: "bNyj1mQVY4c"

--- a/roles/ngrok/meta/argument_specs.yml
+++ b/roles/ngrok/meta/argument_specs.yml
@@ -1,0 +1,16 @@
+---
+argument_specs:
+  main:
+    short_description: Install ngrok.
+    description: >-
+      Downloads and installs ngrok.
+    options:
+      ngrok_force_download:
+        description: >-
+          If True, download ngrok, even if it's already been downloaded.
+        type: bool
+        default: false
+      ngrok_force_install:
+        description: >-
+          If True, install ngrok, even if it's already installed.
+        default: false

--- a/roles/ngrok/tasks/main.yml
+++ b/roles/ngrok/tasks/main.yml
@@ -15,7 +15,7 @@
 
     - name: Download ngrok
       get_url:
-        url: "https://bin.equinox.io/c/{{ ngrok_hash }}/ngrok-v3-stable-darwin-{{ ngrok_zip_arch }}.zip"
+        url: "https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-darwin-{{ ngrok_zip_arch }}.zip"
         dest: "{{ downloads }}/ngrok.zip"
         force: "{{ ngrok_force_download }}"
         mode: u=rw

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -1,11 +1,6 @@
 ---
-# Version of node to install.
-node_version: "22.12.0"
-
-# Version of node to install. None => use the default that came with node. 'latest' => install latest version.
+# Version of npm to install. None => use the default that came with node. 'latest' => install latest version.
 node_npm_version:
-# Version of yarn to install. None => don't install any. 'latest' => install latest version.
-node_yarn_version:
 
 # List of global modules to install.
 # This variable must contain a list of items, each of which nas a name and optional version. The module with the given

--- a/roles/node/meta/argument_specs.yml
+++ b/roles/node/meta/argument_specs.yml
@@ -1,0 +1,32 @@
+---
+argument_specs:
+  main:
+    short_description: Install node using nvm.
+    description: >-
+      Downloads and installs nvm and uses it to install a specific node version.
+    options:
+      node_global_modules_to_install:
+        description: >-
+          A dict of with required `name` and optional `version` keys. The `name` is the name of the npm module to
+          install. The `version` is the specific version.
+          
+          If `version` is omitted, the latest version is installed.
+        type: dict
+        default: {}
+      node_npm_version:
+        description: >-
+          The version of npm to install.
+
+          The special string `latest` will install the latest version.
+          
+          If omitted (i.e., None), no version is installed (i.e., the version that comes with node will be used). This
+          is the default behavior.
+        type: str
+        # Default is None, but this makes validation explode.
+      node_version:
+        description: >-
+          The node version to install. Must be supported by nvm.
+          
+          Do not include the leading `v`. E.g., to install node version v20.0.0, pass "20.0.0".
+        type: str
+        required: true

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -20,16 +20,9 @@
   args:
     creates: "{{ node_version_root }}"
 
-- name: Use correct node.js version
-  shell: "{{ node_source_nvm }} && nvm alias default {{ node_version_string }}"
-
 - name: Install npm
-  shell: "{{ node_source_nvm }} && nvm use default && npm install -g npm@{{ node_npm_version }}"
+  shell: "{{ node_source_nvm }} && nvm use '{{ node_version_string }}' && npm install -g npm@{{ node_npm_version }}"
   when: node_npm_version != None
-
-- name: Install yarn
-  shell: "{{ node_source_nvm }} && nvm use default && npm install -g yarn@{{ node_yarn_version }}"
-  when: node_yarn_version != None
 
 - name: Install global modules
   community.general.npm:

--- a/roles/node_default_version/meta/argument_specs.yml
+++ b/roles/node_default_version/meta/argument_specs.yml
@@ -1,0 +1,14 @@
+---
+argument_specs:
+  main:
+    short_description: Set the default node version in nvm.
+    description: >-
+      Set up the default node version in nvm. The selected version must already be installed (using nvm).
+    options:
+      node_default_version_node_version:
+        description: >-
+          The version of node to make nvm's default.
+          
+          Do not include the leading `v`. E.g., to make installed node version v20.0.0 the default, pass "20.0.0".
+        type: str
+        required: true

--- a/roles/node_default_version/tasks/main.yml
+++ b/roles/node_default_version/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- set_fact:
+    node_default_version_string: "v{{ node_default_version_node_version }}"
+
+# node_source_nvm is set by the node role, on which this role depends.
+- name: Set default node.js version
+  shell: "{{ node_source_nvm }} && nvm alias default {{ node_default_version_string }}"

--- a/roles/one_password_cli/meta/argument_specs.yml
+++ b/roles/one_password_cli/meta/argument_specs.yml
@@ -1,0 +1,29 @@
+---
+argument_specs:
+  main:
+    short_description: Install the 1Password CLI.
+    description: >-
+      Downloads and installs the 1Password CLI.
+    options:
+      one_password_cli_binary_directory:
+        description: >-
+          Directory to which the op binary will be installed.
+        type: path
+        default: /usr/local/bin
+      one_password_cli_force_download:
+        description: >-
+          If True, download the 1Password CLI, even if it's already been downloaded.
+        type: bool
+        required: false
+      one_password_cli_force_install:
+        description: >-
+          If True, install the 1Password CLI, even if it's already been installed.
+        type: bool
+        required: false
+      one_password_cli_verify_gpg_signature:
+        description: >-
+          If True, verify the downloaded binary's GPG signature.
+          
+          Defaults to false, because gpg can be quite flaky.
+        required: false
+        default: false

--- a/roles/picard/meta/argument_specs.yml
+++ b/roles/picard/meta/argument_specs.yml
@@ -1,0 +1,21 @@
+---
+argument_specs:
+  main:
+    short_description: Install MusicBrainz Picard.
+    description: >-
+      Downloads and installs MusicBrainz Picard.
+    options:
+      picard_force_download:
+        description: >-
+          If True, download MusicBrainz Picard, even if it's already been downloaded.
+        type: bool
+        default: false
+      picard_force_install:
+        description: >-
+          If True, install MusicBrainz Picard, even if it's already installed.
+        default: false
+      picard_version:
+        description: >-
+          The version of MusicBrainz Picard to install.
+        required: false
+        # See defaults for default version.

--- a/roles/postman/meta/argument_specs.yml
+++ b/roles/postman/meta/argument_specs.yml
@@ -1,0 +1,29 @@
+---
+argument_specs:
+  main:
+    short_description: Install Postman.
+    description: >-
+      Downloads and installs Postman.
+    options:
+      postman_app_name:
+        description: >-
+          Name of the Postman application
+        type: str
+        default: Postman
+      postman_app_path:
+        description: >-
+          Directory where the Postman application should be installed.
+
+          For example, `/Applications` or `{{ '~/Applications' | expanduser }}` would be reasonable choices.
+        type: path
+        default: /Applications
+      postman_force_download:
+        description: >-
+          If True, download Postman, even if it's already been downloaded.
+        type: bool
+        default: false
+      postman_force_install:
+        description: >-
+          If True, install Postman, even if it's already installed.
+        default: false
+

--- a/roles/r_app/meta/argument_specs.yml
+++ b/roles/r_app/meta/argument_specs.yml
@@ -1,0 +1,21 @@
+---
+argument_specs:
+  main:
+    short_description: Install R.app.
+    description: >-
+      Downloads and installs R.app.
+    options:
+      r_app_force_download:
+        description: >-
+          If True, download R.app, even if it's already been downloaded.
+        type: bool
+        default: false
+      r_app_force_install:
+        description: >-
+          If True, install R.app, even if it's already installed.
+        default: false
+      r_app_version:
+        description: >-
+          The version of R.app to install.
+        required: false
+        # See defaults for default version.

--- a/roles/set_screenshot_location/meta/argument_specs.yml
+++ b/roles/set_screenshot_location/meta/argument_specs.yml
@@ -1,0 +1,16 @@
+---
+argument_specs:
+  main:
+    short_description: Set the default screenshot location.
+    description: >-
+      Set the default screenshot location for macOS's Screenshot.app.
+    options:
+      set_screenshot_location_folder:
+        description: >-
+          Directory to which Screenshot.app will save screenshots.
+          
+          This directory will be created if it doesn't exist. Permissions are granted only to the current user.
+          
+          The default changes the macOS default (~/Desktop) to ~/Documents/Screenshots.
+        type: path
+        default: ~/Documents/Screenshots

--- a/roles/skim/meta/argument_specs.yml
+++ b/roles/skim/meta/argument_specs.yml
@@ -1,0 +1,21 @@
+---
+argument_specs:
+  main:
+    short_description: Install Skim.
+    description: >-
+      Downloads and installs Skim.
+    options:
+      skim_force_download:
+        description: >-
+          If True, download Skim, even if it's already been downloaded.
+        type: bool
+        default: false
+      skim_force_install:
+        description: >-
+          If True, install Skim, even if it's already installed.
+        default: false
+      skim_version:
+        description: >-
+          The version of Skim to install.
+        required: false
+        # See defaults for default version.

--- a/roles/steamcmd/meta/argument_specs.yml
+++ b/roles/steamcmd/meta/argument_specs.yml
@@ -1,0 +1,20 @@
+---
+argument_specs:
+  main:
+    short_description: Install steamcmd.
+    description: >-
+      Downloads and installs steamcmd.
+    options:
+      steamcmd_dest_dir:
+        description: >-
+          Directory to which steamcmd will be installed.
+        default: true
+      steamcmd_force_download:
+        description: >-
+          If True, download steamcmd, even if it's already been downloaded.
+        type: bool
+        default: false
+      steamcmd_force_install:
+        description: >-
+          If True, install steamcmd, even if it's already installed.
+        default: false

--- a/roles/steamcmd/tasks/main.yml
+++ b/roles/steamcmd/tasks/main.yml
@@ -18,6 +18,7 @@
         force: "{{ steamcmd_force_download }}"
         mode: u=rw
 
+    # TODO what if this still exists? Should we wipe it?
     - name: Create steamcmd directory
       file:
         path: "{{ steamcmd_dest_dir }}"
@@ -29,5 +30,6 @@
         src: "{{ downloads }}/steamcmd.tar.gz"
         dest: "{{ steamcmd_dest_dir }}"
 
+    # TODO why does this open the directory in the finder?
     - name: Update steamcmd
       command: "{{ steamcmd_script }} +quit"

--- a/roles/terraform/defaults/main.yml
+++ b/roles/terraform/defaults/main.yml
@@ -2,3 +2,4 @@
 terraform_version: "1.11.2"
 terraform_force_download: false
 terraform_force_install: false
+terraform_binary_directory: /usr/local/bin

--- a/roles/terraform/meta/argument_specs.yml
+++ b/roles/terraform/meta/argument_specs.yml
@@ -1,0 +1,26 @@
+---
+argument_specs:
+  main:
+    short_description: Install terraform.
+    description: >-
+      Downloads and installs terraform.
+    options:
+      terraform_binary_directory:
+        description: >-
+          Directory to which the terraform binary will be installed.
+        type: path
+        default: /usr/local/bin
+      terraform_force_download:
+        description: >-
+          If True, download terraform, even if it's already been downloaded.
+        type: bool
+        default: false
+      terraform_force_install:
+        description: >-
+          If True, install terraform, even if it's already installed.
+        default: false
+      terraform_version:
+        description: >-
+          The version of terraform to install.
+        required: false
+        # See defaults for default version.

--- a/roles/terraform/tasks/main.yml
+++ b/roles/terraform/tasks/main.yml
@@ -21,5 +21,5 @@
     - name: Install terraform
       unarchive:
         src: "{{ downloads }}/terraform.zip"
-        dest: "/usr/local/bin"
+        dest: "{{ terraform_binary_directory }}"
       become: true

--- a/roles/vlc/defaults/main.yml
+++ b/roles/vlc/defaults/main.yml
@@ -1,17 +1,8 @@
 ---
 vlc_version: "3.0.21"
 
-# true forces redownload, even if dmg is already present.
 vlc_force_download: false
-# true forces reinstall, even if app is present.
 vlc_force_install: false
 
-# Destination for the disk image file in the download directory.
-vlc_dmg_name: VLC.dmg
-# Name of the pkg within the mounted disk image.
-vlc_package_name: VLC.pkg
-
-# false to disable metadata retrieval.
 vlc_enable_metadata_retrieval: true
-# false to disable update checking
 vlc_enable_automatic_updates: true

--- a/roles/vlc/meta/argument_specs.yml
+++ b/roles/vlc/meta/argument_specs.yml
@@ -1,0 +1,29 @@
+---
+argument_specs:
+  main:
+    short_description: Install VLC.
+    description: >-
+      Downloads, installs, and configures VLC.
+    options:
+      vlc_enable_metadata_retrieval:
+        description: >-
+          Whether to enable metadata retrieval.
+        default: true
+      vlc_enable_automatic_updates:
+        description: >-
+          Whether to enable automatic updates.
+        default: true
+      vlc_force_download:
+        description: >-
+          If True, download VLC, even if it's already been downloaded.
+        type: bool
+        default: false
+      vlc_force_install:
+        description: >-
+          If True, install VLC, even if it's already installed.
+        default: false
+      vlc_version:
+        description: >-
+          The version of VLC to install.
+        required: false
+        # See defaults for default version.

--- a/roles/vlc/tasks/main.yml
+++ b/roles/vlc/tasks/main.yml
@@ -16,7 +16,7 @@
     install_from_dmg_image_url: "{{ vlc_dmg_url }}"
     install_from_dmg_image_destination: "{{ downloads }}/VLC.dmg"
     install_from_dmg_force_download: "{{ vlc_force_download }}"
-    install_from_dmg_install: "{{ vlc_force_install }}"
+    install_from_dmg_force_install: "{{ vlc_force_install }}"
 
 # See https://community.jamf.com/t5/jamf-pro/suppressing-quot-enable-metadata-retrieval-quot-prompt-in-vlc/m-p/130327
 # and https://forum.videolan.org/viewtopic.php?t=126302 (linked from above).

--- a/roles/xact/meta/argument_specs.yml
+++ b/roles/xact/meta/argument_specs.yml
@@ -1,0 +1,33 @@
+---
+argument_specs:
+  main:
+    short_description: Install xACT.
+    description: >-
+      Downloads and installs xACT.
+    options:
+      xact_app_name:
+        description: >-
+          Name of the xACT application
+        type: str
+        default: xACT
+      xact_app_path:
+        description: >-
+          Directory where the xACT application should be installed.
+
+          For example, `/Applications` or `{{ '~/Applications' | expanduser }}` would be reasonable choices.
+        type: path
+        default: /Applications
+      xact_force_download:
+        description: >-
+          If True, download xACT, even if it's already been downloaded.
+        type: bool
+        default: false
+      xact_force_install:
+        description: >-
+          If True, install xACT, even if it's already installed.
+        default: false
+      xact_version:
+        description: >-
+          The version of xACT to install.
+        required: false
+        # See defaults for default version.

--- a/roles/xquartz/meta/argument_specs.yml
+++ b/roles/xquartz/meta/argument_specs.yml
@@ -1,0 +1,21 @@
+---
+argument_specs:
+  main:
+    short_description: Install XQuartz.
+    description: >-
+      Downloads and installs XQuartz.
+    options:
+      xquartz_force_download:
+        description: >-
+          If True, download XQuartz, even if it's already been downloaded.
+        type: bool
+        default: false
+      xquartz_force_install:
+        description: >-
+          If True, install XQuartz, even if it's already installed.
+        default: false
+      xquartz_version:
+        description: >-
+          The version of XQuartz to install.
+        required: false
+        # See defaults for default version.

--- a/setup-playbook.yml
+++ b/setup-playbook.yml
@@ -39,11 +39,7 @@
         - apps
 
     - name: Install node.js with nvm
-      include_role:
-        name: node
-        apply:
-          tags:
-            - node
+      import_tasks: tasks/install_node.yml
       tags:
         - node
 

--- a/tasks/install_node.yml
+++ b/tasks/install_node.yml
@@ -1,0 +1,23 @@
+---
+- name: Install node
+  include_role:
+    name: node
+    apply:
+      tags:
+        - node
+  vars:
+    node_version: "{{ setup_node_version }}"
+    node_global_modules_to_install: "{{ setup_node_global_modules_to_install }}"
+  tags:
+    - node
+
+- name: Set default node version
+  include_role:
+    name: node_default_version
+    apply:
+      tags:
+        - node
+  vars:
+    node_default_version_node_version: "{{ setup_node_version }}"
+  tags:
+    - node

--- a/vars/node_global_modules.yml
+++ b/vars/node_global_modules.yml
@@ -5,7 +5,7 @@
 #   name is required.
 #   version is optional. If omitted, the default is `latest`.
 ---
-node_global_modules_to_install:
+setup_node_global_modules_to_install:
   aws-cdk:
   aws-cdk-local:
   prettier:

--- a/vars/versions.yml
+++ b/vars/versions.yml
@@ -3,3 +3,6 @@
 ---
 gpgtools_version: "2023.3"
 visualvm_version: "2.1.10"
+
+# Version of node to install and make the default (via nvm)
+setup_node_version: "22.12.0"


### PR DESCRIPTION
`ansible` will validate role args when this is set up, and it serves as documentation. All roles should have a arg specs. Now, most of them do.