### PR TITLE
Add Text::CSV to gnu_parallel. Add cpanm role.

### DIFF
--- a/roles/cpanm/meta/main.yml
+++ b/roles/cpanm/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: macports

--- a/roles/cpanm/tasks/main.yml
+++ b/roles/cpanm/tasks/main.yml
@@ -1,0 +1,20 @@
+# Install cpanm, which is a prerequisite for the cpanm module.
+# https://docs.ansible.com/projects/ansible/latest/collections/community/general/cpanm_module.html
+#
+# Requires macports as a prerequisite.
+---
+- name: Install cpanm
+  macports:
+    name: p5.34-app-cpanminus
+    state: present
+  become: true
+
+- name: Install cpanm-select
+  macports:
+    name: cpanm_select
+    state: present
+  become: true
+
+- name: Select cpanm 5.34
+  command: "/opt/local/bin/port select cpanm cpanm-5.34"
+  become: true

--- a/roles/cpanm/tasks/main.yml
+++ b/roles/cpanm/tasks/main.yml
@@ -18,3 +18,10 @@
 - name: Select cpanm 5.34
   command: "/opt/local/bin/port select cpanm cpanm-5.34"
   become: true
+
+# cpanm installs to local lib by default. It's much easier to use perl libs with this installed.
+- name: Install local::lib
+  macports:
+    name: p5.34-local-lib
+    state: present
+  become: true

--- a/roles/gnu_parallel/tasks/main.yml
+++ b/roles/gnu_parallel/tasks/main.yml
@@ -21,3 +21,10 @@
     path: "{{ throwaway }}/will-cite"
     state: touch
     mode: u=rw,g=r,o=r
+
+# Makes the --csv flag work.
+- name: Install Text::CSV
+  macports:
+    name: p5.34-text-csv
+    state: present
+  become: true


### PR DESCRIPTION
Add `Text::CSV` so that `parallel --csv` works.

Turns out I don't need `cpanm` (since`macports` has `Text::CSV`), but maybe it'll be useful one day.