### PR TITLE
Replace ansible_FACT with ansible_facts['FACT']

### DIFF
--- a/roles/aws_sam_cli/tasks/main.yml
+++ b/roles/aws_sam_cli/tasks/main.yml
@@ -4,7 +4,7 @@
   register: aws_sam_cli_stat
 
 - set_fact:
-    aws_sam_cli_package_name: "aws-sam-cli-macos-{{ ansible_machine }}.pkg"
+    aws_sam_cli_package_name: "aws-sam-cli-macos-{{ ansible_facts['machine'] }}.pkg"
 
 - name: Download AWS SAM CLI installer
   get_url:

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,7 +1,7 @@
 # Install Docker Desktop
 ---
 - set_fact:
-    docker_dmg_arch: "{{ 'amd64' if (ansible_machine == 'x86_64') else ansible_machine }}"
+    docker_dmg_arch: "{{ 'amd64' if (ansible_facts['machine'] == 'x86_64') else ansible_facts['machine'] }}"
 
 - name: Download and install Docker
   include_role:

--- a/roles/doppler/tasks/main.yml
+++ b/roles/doppler/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - set_fact:
     doppler_download_scheme_and_host: "https://cli.doppler.com"
-    doppler_download_query_params: "os=Darwin&arch={{ ansible_machine }}&format=tar"
+    doppler_download_query_params: "os=Darwin&arch={{ ansible_facts['machine'] }}&format=tar"
     doppler_download_dir: "{{ downloads }}/doppler"
 
 - set_fact:

--- a/roles/hashicorp_terraform/tasks/main.yml
+++ b/roles/hashicorp_terraform/tasks/main.yml
@@ -9,7 +9,9 @@
 - when: hashicorp_terraform_force_install or not hashicorp_terraform_stat.stat.exists
   block:
     - set_fact:
-        hashicorp_terraform_arch: "{{ 'amd64' if (ansible_machine == 'x86_64') else ansible_machine }}"
+        hashicorp_terraform_arch: >-
+          {{ 'amd64' if (ansible_facts['machine'] == 'x86_64') else ansible_facts['machine'] }}
+
     - name: Download terraform
       get_url:
         url: "https://releases.hashicorp.com/terraform/{{ hashicorp_terraform_version }}/terraform_{{ hashicorp_terraform_version }}_darwin_{{ hashicorp_terraform_arch }}.zip"

--- a/roles/hashicorp_vault/tasks/main.yml
+++ b/roles/hashicorp_vault/tasks/main.yml
@@ -9,7 +9,7 @@
 - when: hashicorp_vault_force_install or not hashicorp_vault_stat.stat.exists
   block:
     - set_fact:
-        hashicorp_vault_arch: "{{ 'amd64' if (ansible_machine == 'x86_64') else ansible_machine }}"
+        hashicorp_vault_arch: "{{ 'amd64' if (ansible_facts['machine'] == 'x86_64') else ansible_facts['machine'] }}"
     - name: Download vault
       get_url:
         url: "https://releases.hashicorp.com/vault/{{ hashicorp_vault_version }}/vault_{{ hashicorp_vault_version }}_darwin_{{ hashicorp_vault_arch }}.zip"

--- a/roles/ngrok/tasks/main.yml
+++ b/roles/ngrok/tasks/main.yml
@@ -11,7 +11,7 @@
 - when: ngrok_force_install or not (ngrok_stat.stat.executable is defined and ngrok_stat.stat.executable)
   block:
     - set_fact:
-        ngrok_zip_arch: "{{ 'amd64' if (ansible_machine == 'x86_64') else ansible_machine }}"
+        ngrok_zip_arch: "{{ 'amd64' if (ansible_facts['machine'] == 'x86_64') else ansible_facts['machine'] }}"
 
     - name: Download ngrok
       get_url:

--- a/roles/one_password_cli/tasks/main.yml
+++ b/roles/one_password_cli/tasks/main.yml
@@ -4,7 +4,7 @@
 #   https://developer.1password.com/docs/cli/get-started/
 ---
 - set_fact:
-    one_password_cli_arch: "{{ 'amd64' if (ansible_machine == 'x86_64') else ansible_machine }}"
+    one_password_cli_arch: "{{ 'amd64' if (ansible_facts['machine'] == 'x86_64') else ansible_facts['machine'] }}"
     one_password_cli_zip: "{{ downloads }}/1password_cli.zip"
 - set_fact:
     one_password_cli_url: "https://cache.agilebits.com/dist/1P/op2/pkg/v{{ one_password_cli_version }}/op_darwin_{{ one_password_cli_arch }}_v{{ one_password_cli_version }}.zip"

--- a/roles/r_app/tasks/main.yml
+++ b/roles/r_app/tasks/main.yml
@@ -11,7 +11,7 @@
     - name: Download R package
       get_url:
         # Requires big sur or later (note URL).
-        url: "https://cran.r-project.org/bin/macosx/big-sur-{{ ansible_machine }}/base/R-{{ r_app_version }}-{{ ansible_machine }}.pkg"
+        url: "https://cran.r-project.org/bin/macosx/big-sur-{{ ansible_facts['machine'] }}/base/R-{{ r_app_version }}-{{ ansible_facts['machine'] }}.pkg"
         dest: "{{ downloads }}/R.pkg"
         force: "{{ r_app_force_download }}"
         mode: u=rw

--- a/roles/vlc/tasks/main.yml
+++ b/roles/vlc/tasks/main.yml
@@ -2,7 +2,7 @@
 #  https://www.videolan.org/
 ---
 - set_fact:
-    vlc_dmg_suffix: "{{ 'intel64' if (ansible_machine == 'x86_64') else ansible_machine }}"
+    vlc_dmg_suffix: "{{ 'intel64' if (ansible_facts['machine'] == 'x86_64') else ansible_facts['machine'] }}"
 - set_fact:
     vlc_dmg_url: "https://get.videolan.org/vlc/{{ vlc_version }}/macosx/vlc-{{ vlc_version }}-{{ vlc_dmg_suffix }}.dmg"
 - set_fact:

--- a/roles/zoom/tasks/main.yml
+++ b/roles/zoom/tasks/main.yml
@@ -7,7 +7,7 @@
   when: not zoom_force_install
 
 - set_fact:
-    zoom_pkg_arch: "{{ '' if (ansible_machine == 'x86_64') else '?archType=arm64' }}"
+    zoom_pkg_arch: "{{ '' if (ansible_facts['machine'] == 'x86_64') else '?archType=arm64' }}"
 
 - when: zoom_force_install or not (zoom_stat.stat.isdir is defined and zoom_stat.stat.isdir)
   block:

--- a/sudoers-playbook.yml
+++ b/sudoers-playbook.yml
@@ -12,7 +12,7 @@
   become: false
   vars:
     nopasswd: false
-    user: "{{ ansible_user_id }}"
+    user: "{{ ansible_facts['user_id'] }}"
   tasks:
     - set_fact:
         sudoers_line: "{{ user }}            ALL = (ALL) NOPASSWD:ALL"


### PR DESCRIPTION
Changes for newer ansible version to silence warnings.

[Looks like the way facts are accessed is changing](https://forum.ansible.com/t/inject-facts-as-vars-is-defaulting-to-false-in-2-24/44886). Also documented [here](https://docs.ansible.com/projects/ansible/devel/porting_guides/porting_guide_13.html#inject-facts-as-vars).

> The INJECT_FACTS_AS_VARS configuration currently defaults to True, but this is now deprecated and it will switch to False in Ansible 2.24.
>
> When enabled, facts are available both inside the ansible_facts dictionary and as individual variables in the main namespace. In the ansible_facts dictionary, the ansible_ prefix is removed from fact names.
>
> You will receive deprecation warnings if you are accessing ‘injected’ facts.
